### PR TITLE
Feature: Improve handling of empty operators

### DIFF
--- a/headers/tokenization.h
+++ b/headers/tokenization.h
@@ -46,7 +46,7 @@ That is, the word -d'' becomes -d after word splitting and null argument removal
 Note that if no expansion occurs, no splitting is performed.
 */
 
-typedef enum e_operator_ty
+typedef enum e_op_ty
 {
 	OP_PIPE,			// CMD1 | CMD2 (PIPE)
 	OP_REDIRECT,		// > ARG (OUTFILE)
@@ -98,6 +98,7 @@ t_vec		tokenize(t_str_slice inp);
 void		expand_vars(t_vec *tokens, t_symtab_stack *st);
 void		unescape_chars(t_vec *tokens);
 void		tokens_normalize(t_vec *tokens);
+void		tokens_normalize_for_continue_nl_check(t_vec *tokens);
 bool		tokens_to_ast(t_vec *tokens, t_vec *out);
 t_cmd_list	*ast_to_commands(t_vec *ast);
 

--- a/src/ui/parse/parser.c
+++ b/src/ui/parse/parser.c
@@ -1,4 +1,6 @@
 #include "../../../headers/minishell.h"
+#include <stdbool.h>
+#include <stdio.h>
 
 void	parser_destroy(t_parser *p)
 {
@@ -20,12 +22,18 @@ t_parser	parser_init(void *data, t_read_input read_input, t_get_symtab get_symta
 
 static bool	last_tk_is_continue_nl(t_vec *tokens)
 {
-	t_token	*last;
+	t_vec	tokens_clone;
+	t_token_ty	last;
 
 	if (tokens->len == 0)
 		return (false);
-	last = vec_get_last(tokens);
-	return (last->type == TK_CONTINUE_NL);
+	tokens_clone = vec_clone(tokens);
+	if (tokens_clone.mem_err)
+		return (false);
+	tokens_normalize_for_continue_nl_check(&tokens_clone);
+	last = ((t_token*)vec_get_last(&tokens_clone))->type;
+	vec_destroy(&tokens_clone, NULL);
+	return (last == TK_CONTINUE_NL);
 }
 
 static t_ms_status	read_tokens(t_parser *p)
@@ -58,14 +66,115 @@ static t_ms_status	read_tokens(t_parser *p)
 		vec_destroy(&tmp_tokens, NULL);
 		if (!last_tk_is_continue_nl(&p->tokens))
 			break;
-		else
+		else if (cstr_ref(&p->last_input)[p->last_input.len] == '\\')
 			str_pop(&p->last_input);
+		else
+			str_push(&p->last_input, ' ');
 		inp = p->read_input(true, p->data);
 		str_cat(&p->last_input, cstr_view(inp));
-		((t_token *)vec_get_last(&p->tokens))->type = TK_SEPERATOR;
+		if (((t_token *)vec_get_last(&p->tokens))->type == TK_CONTINUE_NL)
+			vec_remove_last(&p->tokens);
 	}
 	tokens_normalize(&p->tokens);
 	return (MS_OK);
+}
+
+static void	str_push_ast(t_str *str, t_ast *ast, bool first)
+{
+	size_t	i;
+
+	if (ast->ty == AST_OP)
+	{
+		if (!first)
+			str_push(str, ' ');
+		str_pushstr(str, cstr_view(op_str(ast->op.ty)));
+		if (ast->op.arg)
+		{
+			str_push(str, ' ');
+			str_pushstr(str, cstr_view(ast->op.arg));
+		}
+		return ;
+	}
+	i = 0;
+	while (ast->cmd[i])
+	{
+		if (!first || i > 0)
+			str_push(str, ' ');
+		str_pushstr(str, cstr_view(ast->cmd[i]));
+		i++;
+	}
+}
+
+static void	ast_printstr(t_vec *ast)
+{
+	size_t	i;
+	t_str	ast_line;
+
+	i = 0;
+	ast_line = str_empty();
+	while (i < ast->len)
+	{
+		str_push_ast(&ast_line, vec_get_at(ast, i), i == 0);
+		i++;
+	}
+	write(2, "[DBG] parsed AST: ", 18);
+	write(2, cstr_ref(&ast_line), ast_line.len);
+	write(2, "\n", 1);
+	str_destroy(&ast_line);
+}
+
+static void	ast_printerr(t_vec *ast, size_t err_i)
+{
+	size_t	i;
+	t_str	ast_line;
+	t_str	err_line;
+
+	i = 0;
+	ast_line = str_empty();
+	err_line = str_empty();
+	while (i < ast->len)
+	{
+		if (i == err_i)
+		{
+			str_pushn(&err_line, ' ', ast_line.len);
+			str_push_ast(&ast_line, vec_get_at(ast, i), i == 0);
+			if (ast_line.len > err_line.len)
+				str_push(&err_line, ' ');
+			str_pushn(&err_line, '^', ast_line.len - err_line.len);
+		}
+		else
+			str_push_ast(&ast_line, vec_get_at(ast, i), i == 0);
+		i++;
+	}
+	str_push(&ast_line, '\n');
+	str_push(&err_line, '\n');
+	write(2, "minishell syntax error:\n", 24);
+	write(2, cstr_ref(&ast_line), ast_line.len);
+	write(2, cstr_ref(&err_line), err_line.len);
+	str_destroy(&ast_line);
+	str_destroy(&err_line);
+}
+
+static bool	ast_has_integrity(t_vec *ast)
+{
+	size_t	i;
+	t_ast	*node;
+	bool	ok;
+
+	i = 0;
+	ok = true;
+	while (i < ast->len)
+	{
+		node = vec_get_at(ast, i);
+		if ((node->ty == AST_OP && node->op.ty == OP_PIPE && i == 0)
+			|| (node->ty == AST_OP && node->op.ty != OP_PIPE && node->op.arg == NULL))
+		{
+			ast_printerr(ast, i);
+			ok = false;
+		}
+		i++;
+	}
+	return (ok);
 }
 
 t_ms_status	parse_next_command(t_parser *p, t_cmd_list	**out)
@@ -86,6 +195,13 @@ t_ms_status	parse_next_command(t_parser *p, t_cmd_list	**out)
 		vec_destroy(&ast, NULL); // TODO
 		return (MS_ERROR);
 	}
+	if (!ast_has_integrity(&ast))
+	{
+		vec_destroy(&ast, NULL);
+		return (MS_OK);
+	}
+	else
+		ast_printstr(&ast);
 	if (p->tokens.len == 0)
 		vec_destroy(&p->tokens, NULL);
 	*out = ast_to_commands(&ast);

--- a/src/ui/token/normalize.c
+++ b/src/ui/token/normalize.c
@@ -111,6 +111,28 @@ static void	remove_all_seperators(t_vec *tokens)
 	}
 }
 
+static void	rm_nl_after_pipe(t_vec	*tokens)
+{
+	t_token	*token;
+	size_t	i;
+
+	i = 0;
+	while (i < tokens->len)
+	{
+		token = vec_get_at(tokens, i);
+		if (token->type == TK_OPERATOR && token->op == OP_PIPE)
+		{
+			if (i + 1 < tokens->len)
+			{
+				token = vec_get_at(tokens, i + 1);
+				if (token->type == TK_NL)
+					vec_remove_at(tokens, i + 1);
+			}
+		}
+		i++;
+	}
+}
+
 // repeating seperators -> single seperator
 // remove seperator before or after one of [TOKEN_OPERATOR, TOKEN_CONTINUE_NL, TOKEN_NL]
 // chained tokens of kind TOKEN_WORD, TOKEN_LITERAL, TOKEN_DQUOTE -> single WORD token
@@ -120,4 +142,36 @@ void	tokens_normalize(t_vec *tokens)
 	remove_redundant_separators(tokens);
 	merge_chained_word_tokens(tokens);
 	remove_all_seperators(tokens);
+	rm_nl_after_pipe(tokens);
+}
+
+static void	add_continue_nl_after_empty_pipe(t_vec *tokens)
+{
+	static const t_token	continue_nl = {.type = TK_CONTINUE_NL};
+	t_token					*token;
+	size_t					i;
+
+	i = 0;
+	while (i < tokens->len)
+	{
+		token = vec_get_at(tokens, i);
+		if (token->type == TK_OPERATOR && token->op == OP_PIPE)
+		{
+			if (i + 1 == tokens->len)
+			{
+				vec_push(tokens, (t_token*)&continue_nl);
+				return ;
+			}
+		}
+		i++;
+	}
+}
+
+void	tokens_normalize_for_continue_nl_check(t_vec *tokens)
+{
+	remove_dup_seperators(tokens);
+	remove_redundant_separators(tokens);
+	remove_all_seperators(tokens);
+	rm_nl_after_pipe(tokens);
+	add_continue_nl_after_empty_pipe(tokens);
 }


### PR DESCRIPTION
Closes #10 
Closes #9 

- Empty operators except for empty pipes give syntax error with indication of where the error occured
- If there is a newline directly after a pipe, the newline is removed and the tokens are accounted for as arguments for the pipe
- Empty pipe will cause minishell to act as if there was a continue_newline token (backslash at the end of the line)
- AST will now be debug printed for all inputs